### PR TITLE
Install babel-plugin-istanbul when use babel

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -82,8 +82,15 @@ module.exports = fountain.Base.extend({
       if (this.options.modules === 'webpack') {
         _.merge(pkg, {
           devDependencies: {
-            'babel-plugin-istanbul': '^2.0.1',
             'karma-webpack': '^1.7.0'
+          }
+        });
+      }
+
+      if (this.options.js === 'babel') {
+        _.merge(pkg, {
+          devDependencies: {
+            'babel-plugin-istanbul': '^2.0.1'
           }
         });
       }

--- a/test/app/index.js
+++ b/test/app/index.js
@@ -125,6 +125,29 @@ test('Configure package.json  with angular1/systemjs/typescript', t => {
   t.deepEqual(context.mergeJson['package.json'], expected);
 });
 
+test('Configure package.json  with angular1/systemjs/babel', t => {
+  const expected = _.merge({}, pkg, {
+    devDependencies: {
+      'angular-mocks': '^1.5.0-beta.2',
+      'gulp-ng-annotate': '^1.1.0',
+      'karma-angular-filesort': '^1.0.0',
+      'karma-ng-html2js-preprocessor': '^0.2.0',
+      'karma-phantomjs-launcher': '^1.0.0',
+      'karma-phantomjs-shim': '^1.1.2',
+      'phantomjs-prebuilt': '^2.1.6',
+      'karma-jspm': '^2.0.2',
+      'babel-plugin-istanbul': '^2.0.1'
+    },
+    eslintConfig: {
+      globals: {
+        expect: true
+      }
+    }
+  });
+  TestUtils.call(context, 'configuring.pkg', {framework: 'angular1', modules: 'systemjs', js: 'babel'});
+  t.deepEqual(context.mergeJson['package.json'], expected);
+});
+
 test('Copy karma.conf.js and karma-auto.conf.js when modules is systemjs', t => {
   TestUtils.call(context, 'configuring.conf', {modules: 'systemjs'});
   t.true(context.copyTemplate['conf/karma.conf.js'].length > 0);

--- a/test/app/index.js
+++ b/test/app/index.js
@@ -43,8 +43,7 @@ test('Configure package.json  with angular1/webpack', t => {
       'karma-phantomjs-launcher': '^1.0.0',
       'karma-phantomjs-shim': '^1.1.2',
       'phantomjs-prebuilt': '^2.1.6',
-      'karma-webpack': '^1.7.0',
-      'babel-plugin-istanbul': '^2.0.1'
+      'karma-webpack': '^1.7.0'
     },
     eslintConfig: {
       globals: {
@@ -95,8 +94,7 @@ test('Configure package.json  with angular2/webpack/typescript', t => {
   const expected = _.merge({}, pkg, {
     devDependencies: {
       'karma-chrome-launcher': '^0.2.3',
-      'karma-webpack': '^1.7.0',
-      'babel-plugin-istanbul': '^2.0.1'
+      'karma-webpack': '^1.7.0'
     }
   });
   TestUtils.call(context, 'configuring.pkg', {framework: 'angular2', modules: 'webpack', js: 'typescript'});


### PR DESCRIPTION
Fix https://github.com/FountainJS/generator-fountain-webapp/issues/147

Note: since we use babel-plugin-istanbul we can activate coverage for Bower + Babel configuration
